### PR TITLE
NuPlayerDecoder: Remove conflicting logging point

### DIFF
--- a/media/libmediaplayerservice/nuplayer/NuPlayerDecoder.cpp
+++ b/media/libmediaplayerservice/nuplayer/NuPlayerDecoder.cpp
@@ -497,7 +497,7 @@ void NuPlayer::Decoder::onResume(bool notifyComplete) {
 
     if (mFormat != NULL) {
         nsecs_t deltaTime = systemTime() - mMsgTime;
-        ALOGD("rsme - flus deltaTime: %lld", deltaTime);
+        //ALOGD("rsme - flus deltaTime: %lld", deltaTime);
         if (deltaTime < 5 * 1000000LL) {
             ALOGD("handleOutputFormatChange again after resume");
             handleOutputFormatChange(mFormat);


### PR DESCRIPTION
* causes different errors on some devices [1] & [2]

[1- oneplus]
yerservice/nuplayer/NuPlayerDecoder.o frameworks/av/media/libmediaplayerservice/nuplayer/NuPlayerDecoder.cpp frameworks/av/media/libmediaplayerservice/nuplayer/NuPlayerDecoder.cpp:500:46: error: format specifies type 'long long' but the argument
 has type 'nsecs_t' (aka 'long') [-Werror,-Wformat]
        ALOGD("rsme - flus deltaTime: %lld", deltaTime);
                                      ~~~~   ^~~~~~~~~
                                      %ld
[2 - oriole]
rameworks/av/media/libmediaplayerservice/nuplayer/NuPlayerDecoder.cpp:500:45: e
rror: format specifies type 'long' but the argument has type 'nsecs_t' (aka 'lon
g long') [-Werror,-Wformat]
        ALOGD("rsme - flus deltaTime: %ld", deltaTime);
                                      ~~~   ^~~~~~~~~
                                      %lld

Change-Id: Ib8d1d3c1c2f9e8800be6c6d35a00c1f087009f2c